### PR TITLE
feat: Initial repository structure and core scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Multi-Profile Dotfile + Arch Bootstrap System (Shadow Walker)
+
+This project provides a modular and portable system for managing dotfiles and environment configurations, with a focus on Arch Linux. It allows users to define multiple configuration "profiles" for different roles, desktop environments, and use cases.
+
+## Core Concepts
+
+*   **Profiles**: Located in the `profiles/` directory, each subdirectory (e.g., `base`, `kde`, `hyprland`) represents a configuration profile. Profiles can contain dotfiles, package lists (`packages.txt`), and metadata (`profile.yml`).
+*   **`shadow` CLI**: The primary tool for managing profiles.
+    *   `./shadow walk <profile_name>`: Applies the specified profile.
+        *   `--add`: Layers the new profile onto the existing configuration.
+        *   `--dry-run`: Shows what changes would be made without applying them.
+        *   `--force`: Overwrites existing configurations without prompting.
+*   **`bootstrap.sh`**: A script to set up the system on a new machine. It can install essential packages, clone this repository, and apply an initial profile.
+    *   `./bootstrap.sh --profile <profile_name>`: Bootstraps the system and applies the given profile.
+
+## Getting Started
+
+1.  **Clone the repository (if not done by bootstrap):**
+    ```bash
+    git clone <repository_url>
+    cd <repository_name>
+    ```
+2.  **Run the bootstrap script (optional, for new systems):**
+    ```bash
+    ./bootstrap.sh --profile <initial_profile_name>
+    ```
+3.  **Apply profiles using the `shadow` tool:**
+    ```bash
+    ./shadow walk base
+    ./shadow walk hyprland --add
+    ```
+
+## Profiles
+
+Each profile in `profiles/` can contain:
+*   Dotfiles (e.g., `.bashrc`, `.config/nvim/init.lua`) that will be symlinked to your home directory by `chezmoi`.
+*   `packages.txt`: A list of packages to be installed for that profile. (Package installation logic is primarily handled by `bootstrap.sh` or manually by the user for now).
+*   `profile.yml`: Metadata about the profile, like its name and description.
+
+## Underlying Tooling
+
+This system uses `chezmoi` under the hood for robust dotfile management.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Placeholder for package installation
+# Add commands to install git and chezmoi here
+echo "Simulating package installation (git, chezmoi)..."
+
+# --- Configuration ---
+DEFAULT_PROFILE="base"
+PREDEFINED_REPO_URL="https://github.com/user/repo.git" # Placeholder
+
+# --- Helper Functions ---
+usage() {
+  echo "Usage: $0 [--profile <profile_name>]"
+  echo ""
+  echo "Bootstraps the dotfiles configuration."
+  echo ""
+  echo "Options:"
+  echo "  --profile <profile_name>  Specify the profile to apply (default: $DEFAULT_PROFILE)."
+  exit 1
+}
+
+# --- Argument Parsing ---
+PROFILE_NAME="$DEFAULT_PROFILE" # Default profile
+
+if [ "$#" -gt 0 ]; then
+  if [ "$1" == "--profile" ]; then
+    if [ -n "$2" ]; then
+      PROFILE_NAME="$2"
+      shift 2
+    else
+      echo "Error: --profile option requires a profile name."
+      usage
+    fi
+  else
+    echo "Error: Unknown option $1"
+    usage
+  fi
+fi
+
+if [ "$#" -gt 0 ]; then
+    echo "Error: Too many arguments."
+    usage
+fi
+
+
+# --- Determine Dotfiles Directory ---
+DOTFILES_DIR=""
+if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+  echo "Running inside a git repository. Using current directory as dotfiles repository."
+  DOTFILES_DIR="$(pwd)"
+else
+  echo "Not running inside a git repository. Cloning predefined repository."
+  # For now, just set the path, actual cloning will be part of chezmoi init
+  DOTFILES_DIR="$HOME/.local/share/chezmoi" # Default chezmoi source path
+  echo "Simulating git clone $PREDEFINED_REPO_URL to $DOTFILES_DIR"
+  # In a real scenario, you'd clone here if not using chezmoi's init --apply
+fi
+echo "Dotfiles directory set to: $DOTFILES_DIR"
+
+
+# --- Call shadow script ---
+echo "Attempting to run shadow script..."
+if [ ! -f "./shadow" ]; then
+    echo "Error: shadow script not found in the current directory."
+    echo "Please ensure bootstrap.sh is run from the root of the dotfiles repository where 'shadow' is located,"
+    echo "or that 'shadow' is in your PATH if running from elsewhere."
+    # As a fallback for the "not in git repo" case, we might need to adjust how shadow is called
+    # For now, we assume if not in a git repo, shadow might be placed alongside bootstrap.sh or in PATH
+    # This part might need refinement based on actual deployment strategy.
+    if [ -f "$DOTFILES_DIR/shadow" ]; then
+        echo "Found shadow script in guessed dotfiles directory: $DOTFILES_DIR"
+        SHADOW_CMD="$DOTFILES_DIR/shadow"
+    else
+        echo "Could not locate shadow script. Exiting."
+        exit 1
+    fi
+else
+    SHADOW_CMD="./shadow"
+fi
+
+echo "Executing: $SHADOW_CMD walk $PROFILE_NAME"
+# Call the shadow script to apply the profile
+# The shadow script itself will handle chezmoi logic
+"$SHADOW_CMD" walk "$PROFILE_NAME"
+
+if [ $? -eq 0 ]; then
+  echo "Bootstrap process completed for profile: $PROFILE_NAME"
+else
+  echo "Bootstrap process failed for profile: $PROFILE_NAME"
+  exit 1
+fi
+
+exit 0

--- a/profiles/base/.bashrc
+++ b/profiles/base/.bashrc
@@ -1,0 +1,3 @@
+# Base .bashrc
+export EDITOR=nvim
+alias ls='ls --color=auto'

--- a/profiles/base/.zshrc
+++ b/profiles/base/.zshrc
@@ -1,0 +1,3 @@
+# Base .zshrc
+export EDITOR=nvim
+alias ls='ls --color=auto'

--- a/profiles/base/packages.txt
+++ b/profiles/base/packages.txt
@@ -1,0 +1,3 @@
+neovim
+tmux
+git

--- a/profiles/base/profile.yml
+++ b/profiles/base/profile.yml
@@ -1,0 +1,2 @@
+name: Base
+description: Base configuration for all systems. Includes common aliases, editor settings, and essential tools.

--- a/profiles/devtools/packages.txt
+++ b/profiles/devtools/packages.txt
@@ -1,0 +1,4 @@
+docker
+docker-compose
+kubectl
+helm

--- a/profiles/devtools/profile.yml
+++ b/profiles/devtools/profile.yml
@@ -1,0 +1,2 @@
+name: Development Tools
+description: Profile for software development. Includes tools like Docker, kubectl, and IDE/editor configurations.

--- a/profiles/hyprland/packages.txt
+++ b/profiles/hyprland/packages.txt
@@ -1,0 +1,4 @@
+hyprland
+waybar
+wofi
+kitty

--- a/profiles/hyprland/profile.yml
+++ b/profiles/hyprland/profile.yml
@@ -1,0 +1,2 @@
+name: Hyprland
+description: Configuration specific to the Hyprland window manager. Includes Wayland utilities and theming.

--- a/profiles/kde/packages.txt
+++ b/profiles/kde/packages.txt
@@ -1,0 +1,3 @@
+dolphin
+konsole
+plasma-desktop

--- a/profiles/kde/profile.yml
+++ b/profiles/kde/profile.yml
@@ -1,0 +1,2 @@
+name: KDE Plasma
+description: Configuration specific to the KDE Plasma desktop environment. Includes KDE applications and settings.

--- a/shadow
+++ b/shadow
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+# Function to display help message
+usage() {
+  echo "Usage: $0 walk <profile_name> [--add] [--dry-run] [--force]"
+  echo ""
+  echo "Manages chezmoi profiles."
+  echo ""
+  echo "Commands:"
+  echo "  walk <profile_name>    Apply the specified profile."
+  echo ""
+  echo "Options for walk command:"
+  echo "  --add                  Add the profile to the existing configuration (instead of replacing)."
+  echo "  --dry-run              Show what changes would be made without actually applying them."
+  echo "  --force                Overwrite existing configurations without prompting."
+  exit 1
+}
+
+# Main script logic
+if [ "$#" -eq 0 ]; then
+  usage
+fi
+
+COMMAND="$1"
+shift
+
+# Check for chezmoi installation
+if ! command -v chezmoi &> /dev/null; then
+  echo "Error: chezmoi is not installed. Please install chezmoi first."
+  echo "See: https://www.chezmoi.io/install/"
+  exit 1
+fi
+
+case "$COMMAND" in
+  walk)
+    ADD_MODE=false
+    DRY_RUN_MODE=false
+    FORCE_MODE=false
+    PROFILE_NAME=""
+    REPO_ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)" # Get repo root or current dir
+
+    # Parse options for walk command
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --add)
+          ADD_MODE=true
+          shift
+          ;;
+        --dry-run)
+          DRY_RUN_MODE=true
+          shift
+          ;;
+        --force)
+          FORCE_MODE=true
+          shift
+          ;;
+        -*)
+          echo "Unknown option: $1"
+          usage
+          ;;
+        *)
+          if [ -z "$PROFILE_NAME" ]; then
+            PROFILE_NAME="$1"
+          else
+            echo "Too many arguments. Profile name already set to '$PROFILE_NAME'."
+            usage
+          fi
+          shift
+          ;;
+      esac
+    done
+
+    if [ -z "$PROFILE_NAME" ]; then
+      echo "Error: Profile name not specified for walk command."
+      usage
+    fi
+
+    # Determine chezmoi source path
+    # Assuming 'profiles' directory is at the root of where the shadow script is.
+    # If shadow script is at repo root, and profiles/ is also at repo root.
+    SOURCE_PATH="$REPO_ROOT_DIR/profiles/$PROFILE_NAME"
+
+    if [ ! -d "$SOURCE_PATH" ]; then
+      echo "Error: Profile directory '$SOURCE_PATH' not found."
+      exit 1
+    fi
+
+    echo "Executing 'walk' command for profile: $PROFILE_NAME"
+    echo "  Source path: $SOURCE_PATH"
+
+    # Construct chezmoi command
+    CHEZMOI_CMD="chezmoi apply --source $SOURCE_PATH"
+
+    if [ "$DRY_RUN_MODE" = true ]; then
+      CHEZMOI_CMD="$CHEZMOI_CMD --dry-run"
+      echo "  Mode: Dry run"
+    fi
+
+    if [ "$FORCE_MODE" = true ]; then
+      CHEZMOI_CMD="$CHEZMOI_CMD --force"
+      echo "  Mode: Force"
+    fi
+
+    if [ "$ADD_MODE" = true ]; then
+      # chezmoi apply inherently handles adding/merging.
+      # The --add flag is more for our internal logic/history.
+      echo "  Mode: Add (profile will be applied, potentially merging with existing)"
+    fi
+
+    echo "  Executing: $CHEZMOI_CMD"
+    # Execute chezmoi command
+    # In a real environment, you would run $CHEZMOI_CMD directly.
+    # For testing in environments without chezmoi, we'll simulate it.
+    # $CHEZMOI_CMD
+    # Simulating successful execution for now
+    CHEZMOI_EXIT_CODE=0
+    echo "  (Simulated: $CHEZMOI_CMD)"
+
+
+    if [ $CHEZMOI_EXIT_CODE -eq 0 ]; then
+      echo "  chezmoi command executed successfully."
+      if [ "$DRY_RUN_MODE" = false ]; then
+        HISTORY_FILE="$REPO_ROOT_DIR/.profile-history"
+        HISTORY_ENTRY="$PROFILE_NAME"
+        if [ "$ADD_MODE" = true ]; then
+          HISTORY_ENTRY="$PROFILE_NAME (added)"
+        fi
+        echo "$(date '+%Y-%m-%d %H:%M:%S') - $HISTORY_ENTRY" >> "$HISTORY_FILE"
+        echo "  Profile '$PROFILE_NAME' recorded in $HISTORY_FILE"
+      else
+        echo "  Dry run mode, no changes made and history not updated."
+      fi
+    else
+      echo "  Error executing chezmoi command (exit code: $CHEZMOI_EXIT_CODE)."
+      exit 1 # Propagate error
+    fi
+    ;;
+  *)
+    echo "Unknown command: $COMMAND"
+    usage
+    ;;
+esac


### PR DESCRIPTION
Sets up the foundational elements of the multi-profile dotfile management system.

Includes:
- Basic directory structure with `profiles/` (base, kde, hyprland, devtools).
- `shadow` CLI wrapper for profile application using `chezmoi` (simulated for now), with `walk`, `--add`, `--dry-run`, `--force` options and `.profile-history` tracking.
- `bootstrap.sh` script for initial setup, package installation placeholders, and running `shadow walk`.
- Initial dotfiles (`.bashrc`, `.zshrc`) and `packages.txt` for base and other profiles.
- `profile.yml` metadata files for each profile.
- A `README.md` with project overview and usage instructions.