### PR TITLE
Fix shellcheck issues

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -159,11 +159,8 @@ else
 fi
 
 echo "Executing: $SHADOW_CMD walk $PROFILE_NAME"
-# Call the shadow script to apply the profile
-# The shadow script itself will handle chezmoi logic
-"$SHADOW_CMD" walk "$PROFILE_NAME"
-
-if [ $? -eq 0 ]; then
+# Call the shadow script to apply the profile and check the result directly
+if "$SHADOW_CMD" walk "$PROFILE_NAME"; then
   echo "Bootstrap process completed for profile: $PROFILE_NAME"
 else
   echo "Bootstrap process failed for profile: $PROFILE_NAME"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -35,15 +35,16 @@ install_package() {
   local pkgs_to_install=("$@")
   echo "Attempting to install: ${pkgs_to_install[*]}"
 
+  local exit_code=0
   case "$OS_FAMILY" in
     "arch")
-      sudo pacman -S --noconfirm "${pkgs_to_install[@]}"
+      sudo pacman -S --noconfirm "${pkgs_to_install[@]}" || exit_code=$?
       ;;
     "debian")
-      sudo apt-get update && sudo apt-get install -y "${pkgs_to_install[@]}"
+      sudo apt-get update && sudo apt-get install -y "${pkgs_to_install[@]}" || exit_code=$?
       ;;
     "fedora")
-      sudo dnf install -y "${pkgs_to_install[@]}"
+      sudo dnf install -y "${pkgs_to_install[@]}" || exit_code=$?
       ;;
     "macos")
       if ! command -v brew &> /dev/null; then
@@ -51,7 +52,7 @@ install_package() {
         echo "Visit https://brew.sh for installation instructions."
         return 1 # Indicate failure to install dependency
       fi
-      brew install "${pkgs_to_install[@]}"
+      brew install "${pkgs_to_install[@]}" || exit_code=$?
       ;;
     "unknown")
       echo "OS family is unknown or not supported by this script for automatic package installation."
@@ -64,7 +65,7 @@ install_package() {
       ;;
   esac
 
-  if [ $? -ne 0 ]; then
+  if [ $exit_code -ne 0 ]; then
     echo "Error: Package installation failed for: ${pkgs_to_install[*]}"
     return 1
   fi


### PR DESCRIPTION
## Summary
- fix exit status check in bootstrap script
- improve install_package error handling

## Testing
- `shellcheck -x shadow bootstrap.sh lib/utils.sh`
- `bash -n shadow`
- `bash -n bootstrap.sh`
- `bash -n lib/utils.sh`
- `./shadow walk base --dry-run` *(fails: chezmoi not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684eedac3998832eb93a0b015f58e685